### PR TITLE
Ensure tensorflow module is installed

### DIFF
--- a/scripts/configure-pi.yaml
+++ b/scripts/configure-pi.yaml
@@ -149,3 +149,12 @@
       become_user: peec
       register: poetry_install
       changed_when: poetry_install.rc == 0
+
+    - name: Make sure tensorflow is installed
+      ansible.builtin.command:
+        cmd: poetry run pip install tensorflow==2.15.0
+        chdir: PumaGuard
+      become: true
+      become_user: peec
+      register: tensorflow_install
+      changed_when: tensorflow_install.rc == 0


### PR DESCRIPTION
For some reason poetry is not installing tensorflow. Run pip to make
sure the module is actually installed.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
