### PR TITLE
Add snapcraft-preload

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,21 +13,30 @@ description: |
 
 apps:
   pumaguard-server:
-    command: bin/pumaguard-server
+    command: bin/snapcraft-preload $SNAP/bin/python3 $SNAP/bin/pumaguard-server
     completer: bin/server-bash-completions.sh
     plugs:
       - home
   pumaguard-classify:
-    command: bin/pumaguard-classify
+    command: bin/snapcraft-preload $SNAP/bin/python3 $SNAP/bin/pumaguard-classify
     completer: bin/classify-bash-completions.sh
     plugs:
       - home
   pumaguard-train:
-    command: bin/pumaguard-train
+    command: bin/snapcraft-preload $SNAP/bin/python3 $SNAP/bin/pumaguard-train
     plugs:
       - home
 
 parts:
+  snapcraft-preload:
+    source: https://github.com/sergiusens/snapcraft-preload.git
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/
+    build-packages:
+      - on amd64:
+          - gcc-multilib
+          - g++-multilib
   pumaguard:
     plugin: python
     source: .


### PR DESCRIPTION
Python multiprocesing uses a semaphore in /dev/shm which fails under
strict confinement [1, 2].

[1] https://forum.snapcraft.io/t/snapcraft-preload-and-dev-shm-access/28200/2
[2] https://github.com/sergiusens/snapcraft-preload

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
