### PR TITLE
Globally turn off TF_ENABLE_ONEDNN_OPTS

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,9 @@ description: |
   monitoring, research, and conservation efforts. The model is trained on a
   labeled dataset and validated using a separate set of images.
 
+environment:
+  TF_ENABLE_ONEDNN_OPTS: 0
+
 apps:
   pumaguard-server:
     command: bin/snapcraft-preload $SNAP/bin/python3 $SNAP/bin/pumaguard-server


### PR DESCRIPTION
This should eventually be done using a command line option or similar so
that we can enable this option on platforms where it makes sense.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
