### PR TITLE
Add prime directory to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docs/build/*
+prime/*
 __pycache__
 *.snap
 venv/*


### PR DESCRIPTION
When testing snaps this directory is created and should be ignored.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
