### PR TITLE
Add additional sleep before processing

### DIFF
--- a/pumaguard/server.py
+++ b/pumaguard/server.py
@@ -141,6 +141,7 @@ class FolderObserver:
                         break
                     filepath = line.strip()
                     logger.info('New file detected: %s', filepath)
+                    time.sleep(2)
                     if self._wait_for_file_stability(filepath):
                         threading.Thread(
                             target=self._handle_new_file,
@@ -157,6 +158,7 @@ class FolderObserver:
                 for new_file in new_files:
                     filepath = os.path.join(self.folder, new_file)
                     logger.info('New file detected: %s', filepath)
+                    time.sleep(2)
                     if self._wait_for_file_stability(filepath):
                         threading.Thread(
                             target=self._handle_new_file,


### PR DESCRIPTION
If pumaguard is running inside WSL and the FTP server in Windows,
pumaguard won't be able to test whether the newly detected file is still
open by the FTP server.

This change adds a sleep before processing the file to hopefully
mitigate this issue.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
