### PR TITLE
Add model caching and thread/memory fixes

### DIFF
--- a/pumaguard/server.py
+++ b/pumaguard/server.py
@@ -79,11 +79,11 @@ class FolderObserver:
     """
 
     def __init__(self, folder: str, method: str, presets: Preset):
-        self.folder = folder
-        self.method = method
-        self.presets = presets
+        self.folder: str = folder
+        self.method: str = method
+        self.presets: Preset = presets
         # self.model = model_factory(presets).model
-        self._stop_event = threading.Event()
+        self._stop_event: threading.Event = threading.Event()
 
     def start(self):
         """
@@ -215,10 +215,11 @@ class FolderObserver:
         Arguments:
             filepath -- The path of the new file.
         """
-        logger.debug("Acquiring classification lock")
+        me = threading.current_thread()
+        logger.debug("Acquiring classification lock (%s)", me.name)
         lock = acquire_lock()
         logger.debug("Acquired lock after %d seconds", lock.time_waited())
-        if lock.time_waited() > 10 * 60:
+        if lock.time_waited() > 1 * 60:
             logger.info(
                 "Could not acquire lock in time, skipping classification"
             )
@@ -235,6 +236,7 @@ class FolderObserver:
                 )
                 playsound(sound_file_path)
         lock.release()
+        logger.debug("Exiting (%s)", me.name)
 
 
 class FolderManager:


### PR DESCRIPTION
Add thread-safe get_cached_model and clear_model_cache and use them in
classify_image_two_stage to avoid repeatedly reloading models. Use context
manager for image loading, close figures explicitly and call gc.collect to free
memory. Add type annotations to FolderObserver fields, log thread name when
acquiring/releasing locks, and reduce lock wait threshold to 1 minute.
