### PR TITLE
Add file stabilization extra wait setting

### DIFF
--- a/pumaguard/presets.py
+++ b/pumaguard/presets.py
@@ -40,6 +40,7 @@ class Preset:
         self.batch_size = 16
         self.notebook_number = 1
         self.color_mode = "rgb"
+        self.file_stabilization_extra_wait = 0
         self.epochs = 300
         self.image_dimensions: tuple[int, int] = (128, 128)
         self.lion_directories: list[str] = []
@@ -121,14 +122,16 @@ class Preset:
             isinstance(p, str) for p in validation_no_lions
         ):
             raise ValueError(
-                "expected validation-no-lion-directories "
-                "to be a list of paths"
+                "expected validation-no-lion-directories to be a list of paths"
             )
         self.validation_no_lion_directories = validation_no_lions
         self.with_augmentation = settings.get("with-augmentation", False)
         self.batch_size = settings.get("batch-size", 1)
         self.alpha = float(settings.get("alpha", 1e-5))
         self.color_mode = settings.get("color-mode", "rgb")
+        self.file_stabilization_extra_wait = settings.get(
+            "file-stabilization-extra-wait", 0
+        )
         self.play_sound = settings.get("play-sound", True)
         self.print_download_progress = settings.get(
             "print-download-progress", True
@@ -155,6 +158,7 @@ class Preset:
             "alpha": self.alpha,
             "batch-size": self.batch_size,
             "color-mode": self.color_mode,
+            "file-stabilization-extra-wait": self.file_stabilization_extra_wait,
             "epochs": self.epochs,
             "image-dimensions": self.image_dimensions,
             "lion-directories": self.lion_directories,
@@ -236,9 +240,29 @@ class Preset:
         """
         if notebook < 1:
             raise ValueError(
-                "notebook can not be zero " f"or negative ({notebook})"
+                f"notebook can not be zero or negative ({notebook})"
             )
         self._notebook_number = notebook
+
+    @property
+    def file_stabilization_extra_wait(self) -> int:
+        """
+        Get extra wait.
+        """
+        return (
+            self._file_stabilization_extra_wait
+            if hasattr(self, "_file_stabilization_extra_wait")
+            else 0
+        )
+
+    @file_stabilization_extra_wait.setter
+    def file_stabilization_extra_wait(self, extra_wait: int):
+        """
+        Set the extra wait.
+        """
+        if extra_wait < 0:
+            raise ValueError(f"extra_wait can not be negative ({extra_wait})")
+        self._file_stabilization_extra_wait = extra_wait
 
     @property
     def model_version(self) -> str:
@@ -353,9 +377,7 @@ class Preset:
         Set the number of color channels.
         """
         if channels not in [1, 3]:
-            raise ValueError(
-                "illegal number of color " f"channels ({channels})"
-            )
+            raise ValueError(f"illegal number of color channels ({channels})")
         self._number_color_channels = channels
         if channels == 1:
             self._color_mode = "grayscale"

--- a/pumaguard/server.py
+++ b/pumaguard/server.py
@@ -177,6 +177,14 @@ class FolderObserver:
                     filepath = line.strip()
                     logger.info("New file detected: %s", filepath)
                     if self._wait_for_file_stability(filepath):
+                        if self.presets.file_stabilization_extra_wait > 0:
+                            logger.debug(
+                                "Waiting an extra %f:.2 seconds",
+                                self.presets.file_stabilization_extra_wait,
+                            )
+                            time.sleep(
+                                self.presets.file_stabilization_extra_wait
+                            )
                         threading.Thread(
                             target=self._handle_new_file,
                             args=(filepath,),
@@ -195,6 +203,14 @@ class FolderObserver:
                     filepath = os.path.join(self.folder, new_file)
                     logger.info("New file detected: %s", filepath)
                     if self._wait_for_file_stability(filepath):
+                        if self.presets.file_stabilization_extra_wait > 0:
+                            logger.debug(
+                                "Waiting an extra %f:.2 seconds",
+                                self.presets.file_stabilization_extra_wait,
+                            )
+                            time.sleep(
+                                self.presets.file_stabilization_extra_wait
+                            )
                         threading.Thread(
                             target=self._handle_new_file,
                             args=(filepath,),

--- a/pylintrc
+++ b/pylintrc
@@ -4,6 +4,7 @@ suggestion-mode = yes
 disable =
     R0801,
     R0902,
+    R0912,
     R0914,
     R0915,
     W0511,


### PR DESCRIPTION
Default is 0. FolderObserver now waits the extra interval after a file
is detected stable and logs a debug message. Also fix some error message
f-string formatting.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
